### PR TITLE
fix core/baseservices to use the absolute path

### DIFF
--- a/src/core/baseservices.go
+++ b/src/core/baseservices.go
@@ -3,6 +3,7 @@ package core
 import (
 	"fmt"
 	"os"
+    "path/filepath"
 
 	"github.com/netgusto/nodebook/src/core/shared/recipe"
 	"github.com/netgusto/nodebook/src/core/shared/service"
@@ -14,8 +15,14 @@ func baseServices(notebooksPath string) (*service.RecipeRegistry, *service.Noteb
 	recipeRegistry := service.NewRecipeRegistry()
 	recipe.AddRecipesToRegistry(recipeRegistry)
 
+    absBookPath, err := filepath.Abs(notebooksPath)
+    if err != nil {
+        fmt.Println("Could not get absolute path")
+        os.Exit(1)
+    }
+
 	// Notebook registry
-	nbRegistry := service.NewNotebookRegistry(notebooksPath, recipeRegistry)
+	nbRegistry := service.NewNotebookRegistry(absBookPath, recipeRegistry)
 
 	// Find notebooks
 	notebooks, err := nbRegistry.FindNotebooks(nbRegistry.GetNotebooksPath())


### PR DESCRIPTION
I submitted a patch, but here is a pull request as well. 

This patch allows users to enter a relative path on the command line rather than needing an absolute path. I ran into this issue when I installed it and it failed. I traced it down to having used  ./foo rather than /other/files/foo. 

The new code takes the path in core/baseservices and use Abs() to return the path.

The only issue is that your code has a wrapper around the case where err != nil. I did not follow investigate that part well enough to understand if it was needed, or how it should be done.